### PR TITLE
Uodate minitest.rb for backward-compatible

### DIFF
--- a/lib/minitest.rb
+++ b/lib/minitest.rb
@@ -9,7 +9,7 @@ require "etc"
 # :include: README.rdoc
 
 module Minitest
-  VERSION = "5.16.0" # :nodoc:
+  VERSION = "6.0.0" # :nodoc:
 
   @@installed_at_exit ||= false
   @@after_run = []


### PR DESCRIPTION
Minitest upgraded to 5.16 in June 2022 which requires >= 2.6, This is a breaking change and broking existing applications that are using rails 5.2.3 and ruby version >2.5 and <2.6.

ERROR:  Error installing rails:
        minitest requires Ruby version < 4.0, >= 2.6. The current ruby version is 2.5.0.


According to Versioning.
Given a version number MAJOR.MINOR.PATCH, increment the:

MAJOR version when you make incompatible API changes,
MINOR version when you add functionality in a backward-compatible manner, and
PATCH version when you make backward-compatible bug fixes.

As its makes incompatible API changes, it should be a major release as we are moving from ruby 2.2>= to 2.6>=.

Please approve changes.